### PR TITLE
feat: close popup when opening transaction page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ mise run check # Run all checks (typecheck + format:check + lint + test) (alias:
 
 This rule applies to all code changes, no exceptions.
 
+**CRITICAL**: After source code changes pass all checks, you MUST run `mise run build` and instruct the user to load the built extension in Chrome and verify the actual behavior manually. Tests verify correctness of logic, not real-world behavior in the browser.
+
 ## Architecture
 
 ### Chrome Extension Structure (WXT)

--- a/src/entrypoints/popup/Popup.test.tsx
+++ b/src/entrypoints/popup/Popup.test.tsx
@@ -15,8 +15,9 @@ describe('Popup', () => {
     expect(screen.getByText('MoneyForward 入出金')).toBeInTheDocument();
   });
 
-  it('opens transaction page when button is clicked', () => {
+  it('opens transaction page and closes popup when button is clicked', () => {
     const createSpy = vi.spyOn(chrome.tabs, 'create');
+    const closeSpy = vi.spyOn(window, 'close').mockImplementation(() => {});
 
     render(<Popup />);
     const button = screen.getByText('MoneyForward 入出金');
@@ -26,5 +27,6 @@ describe('Popup', () => {
     expect(createSpy).toHaveBeenCalledWith({
       url: 'https://moneyforward.com/cf',
     });
+    expect(closeSpy).toHaveBeenCalled();
   });
 });

--- a/src/entrypoints/popup/Popup.test.tsx
+++ b/src/entrypoints/popup/Popup.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Popup from './Popup';
 
@@ -15,7 +15,7 @@ describe('Popup', () => {
     expect(screen.getByText('MoneyForward 入出金')).toBeInTheDocument();
   });
 
-  it('opens transaction page and closes popup when button is clicked', () => {
+  it('opens transaction page and closes popup when button is clicked', async () => {
     const createSpy = vi.spyOn(chrome.tabs, 'create');
     const closeSpy = vi.spyOn(window, 'close').mockImplementation(() => {});
 
@@ -27,6 +27,8 @@ describe('Popup', () => {
     expect(createSpy).toHaveBeenCalledWith({
       url: 'https://moneyforward.com/cf',
     });
-    expect(closeSpy).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(closeSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/src/entrypoints/popup/Popup.tsx
+++ b/src/entrypoints/popup/Popup.tsx
@@ -1,6 +1,7 @@
 export default function Popup() {
   const handleOpenTransactionPage = () => {
     chrome.tabs.create({ url: 'https://moneyforward.com/cf' });
+    window.close();
   };
 
   return (

--- a/src/entrypoints/popup/Popup.tsx
+++ b/src/entrypoints/popup/Popup.tsx
@@ -1,7 +1,13 @@
 export default function Popup() {
   const handleOpenTransactionPage = () => {
-    chrome.tabs.create({ url: 'https://moneyforward.com/cf' });
-    window.close();
+    chrome.tabs
+      .create({ url: 'https://moneyforward.com/cf' })
+      .catch((error) => {
+        console.error('Failed to open transaction page:', error);
+      })
+      .finally(() => {
+        window.close();
+      });
   };
 
   return (


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Close the extension popup automatically when the "入出金ページを開く" button is clicked.

## Reason for change

Closes #173

## Changes

- Add `window.close()` after `chrome.tabs.create()` in the button handler
- Update test to verify popup closes on button click

## Notes