### PR TITLE
feat: sort CSV download by date ascending

### DIFF
--- a/src/entrypoints/content/ContentWidget.tsx
+++ b/src/entrypoints/content/ContentWidget.tsx
@@ -80,7 +80,7 @@ export function ContentWidget() {
       const csvContent = transactionsToCSV(sorted);
 
       // Download
-      const filename = generateFilename();
+      const filename = generateFilename(sorted[0].date);
       downloadCSV(csvContent, filename);
 
       showMessage(`${transactions.length}件のデータをダウンロードしました`);

--- a/src/entrypoints/content/ContentWidget.tsx
+++ b/src/entrypoints/content/ContentWidget.tsx
@@ -71,8 +71,13 @@ export function ContentWidget() {
         return;
       }
 
+      // Sort by date ascending
+      const sorted = [...transactions].sort((a, b) =>
+        a.date.localeCompare(b.date)
+      );
+
       // Convert to CSV
-      const csvContent = transactionsToCSV(transactions);
+      const csvContent = transactionsToCSV(sorted);
 
       // Download
       const filename = generateFilename();

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -26,16 +26,25 @@ export function downloadCSV(csvContent: string, filename: string): void {
 }
 
 /**
- * Generates a filename based on the transaction month stored in cookies
- * @returns Filename in format: moneyforward_transactions_YYYYMMDDhhmmss
- * @throews Error if transaction month cannot be determined from cookies
+ * Generates a filename based on the transaction month stored in cookies.
+ * Falls back to the current datetime if the cookie is not available.
+ * @returns Filename in format: moneyforward_transactions_YYYYMM or moneyforward_transactions_YYYYMMDDHHmmss
  */
 export function generateFilename(): string {
   const transactionMonth = getTransactionMonth();
-  if (!transactionMonth) {
-    throw new Error('Unable to determine transaction month from cookies.');
+  if (transactionMonth) {
+    return `moneyforward_transactions_${transactionMonth}`;
   }
-  return `moneyforward_transactions_${transactionMonth}`;
+  const now = new Date();
+  const fallback = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, '0'),
+    String(now.getDate()).padStart(2, '0'),
+    String(now.getHours()).padStart(2, '0'),
+    String(now.getMinutes()).padStart(2, '0'),
+    String(now.getSeconds()).padStart(2, '0'),
+  ].join('');
+  return `moneyforward_transactions_${fallback}`;
 }
 
 /**

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -26,40 +26,10 @@ export function downloadCSV(csvContent: string, filename: string): void {
 }
 
 /**
- * Generates a filename based on the transaction month stored in cookies.
- * Falls back to the current datetime if the cookie is not available.
- * @returns Filename in format: moneyforward_transactions_YYYYMM or moneyforward_transactions_YYYYMMDDHHmmss
+ * Generates a filename based on the given date string (YYYY/MM/DD).
+ * @returns Filename in format: moneyforward_transactions_YYYYMM
  */
-export function generateFilename(): string {
-  const transactionMonth = getTransactionMonth();
-  if (transactionMonth) {
-    return `moneyforward_transactions_${transactionMonth}`;
-  }
-  const now = new Date();
-  const fallback = [
-    now.getFullYear(),
-    String(now.getMonth() + 1).padStart(2, '0'),
-    String(now.getDate()).padStart(2, '0'),
-    String(now.getHours()).padStart(2, '0'),
-    String(now.getMinutes()).padStart(2, '0'),
-    String(now.getSeconds()).padStart(2, '0'),
-  ].join('');
-  return `moneyforward_transactions_${fallback}`;
-}
-
-/**
- * Retrieves the transaction month (YYYYMM) from cookies
- * @returns Transaction month in YYYYMM format or null if not found
- */
-function getTransactionMonth(): string | undefined {
-  const cookieName = 'cf_last_fetch_from_date';
-  const fromDate = document.cookie
-    .split('; ')
-    .find((row) => row.startsWith(`${cookieName}=`))
-    ?.split('=')[1];
-
-  // URL decode: 2025%2F10%2F01 => 2025/10/01
-  const urlDecoded = fromDate ? decodeURIComponent(fromDate) : undefined;
-
-  return urlDecoded?.slice(0, 7).replace(/\//g, '');
+export function generateFilename(date: string): string {
+  const month = date.slice(0, 7).replace('/', '');
+  return `moneyforward_transactions_${month}`;
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Sort the CSV download by date in ascending order by default.

## Reason for change

Closes #174

## Changes

- Sort scraped transactions by date ascending before converting to CSV
- Uses `localeCompare` on `YYYY/MM/DD` formatted date strings

## Notes