### PR TITLE
feat: add release script as mise task

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ To update the extension icons, you need to create three sizes (16x16, 48x48, 128
 
 To create a new release:
 
-1. Create and push a version tag:
+1. Bump the version and create a tag:
 
     ```sh
-    git tag v1.0.0
-    git push origin v1.0.0
+    mise run release -- <major|minor|patch>
+    git push && git push origin <tag>
     ```
 
 2. GitHub Actions will automatically:

--- a/mise.toml
+++ b/mise.toml
@@ -83,8 +83,8 @@ description = "Clean and rebuild project"
 run = [{ task = "clean" }, { task = "install" }, { task = "build" }]
 alias = "cb"
 
-[tasks.release]
-description = "Run all tasks for release"
+[tasks.pre-release]
+description = "Run all tasks for release (clean + install + fix-and-check + build)"
 run = [
   { task = "clean" },
   { task = "install" },

--- a/mise/tasks/release
+++ b/mise/tasks/release
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#MISE description="Bump version in package.json and create annotated git tag (usage: mise run release -- <major|minor|patch>)"
+set -euo pipefail
+
+for cmd in git jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    printf "[ERROR] Required command '%s' not found. Please install it.\n" "$cmd" >&2
+    exit 1
+  fi
+done
+
+level="${1:-}"
+if [ -z "$level" ]; then
+  printf "Usage: mise run release -- <major|minor|patch>\n" >&2
+  exit 1
+fi
+
+case "$level" in
+  major|minor|patch) ;;
+  *)
+    printf "[ERROR] Invalid bump level '%s'. Must be one of: major, minor, patch\n" "$level" >&2
+    exit 1
+    ;;
+esac
+
+current_version=$(jq -re '.version' package.json)
+
+if [ -z "$current_version" ] || [ "$current_version" = "null" ]; then
+  printf "[ERROR] Failed to get version from package.json\n" >&2
+  exit 1
+fi
+
+IFS='.' read -r major minor patch <<< "$current_version"
+case "$level" in
+  major) major=$((major + 1)); minor=0; patch=0 ;;
+  minor) minor=$((minor + 1)); patch=0 ;;
+  patch) patch=$((patch + 1)) ;;
+esac
+next_version="${major}.${minor}.${patch}"
+tag="v${next_version}"
+
+if git rev-parse "$tag" >/dev/null 2>&1; then
+  printf "[ERROR] Tag '%s' already exists\n" "$tag" >&2
+  exit 1
+fi
+
+printf "Bump version from v%s to %s? [y/N] " "$current_version" "$tag"
+read -r answer
+if [ "$answer" != "y" ] && [ "$answer" != "Y" ]; then
+  printf "Aborted.\n"
+  exit 0
+fi
+
+tmp=$(mktemp)
+jq --arg v "$next_version" '.version = $v' package.json > "$tmp"
+mv "$tmp" package.json
+
+git add package.json
+git commit -m "chore: bump version to ${tag}"
+
+printf "Creating release tag: %s\n" "$tag"
+git tag -a "$tag" -m "Release ${tag}"
+
+printf "Tag '%s' created successfully\n" "$tag"
+printf "To push, run:\n"
+printf "  git push && git push origin %s\n" "$tag"


### PR DESCRIPTION
## Summary

- Add `mise/tasks/release` script that bumps version in `package.json` and creates an annotated git tag
- Rename existing `[tasks.release]` to `[tasks.pre-release]` to avoid conflict

## Usage

```bash
mise run release -- <major|minor|patch>
```

## Closes

Closes #172