### PR TITLE
fix: read manifest version from package.json dynamically

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'wxt';
 import react from '@vitejs/plugin-react';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -21,7 +22,9 @@ export default defineConfig({
   manifest: {
     name: 'MoneyForward Web Tools',
     description: 'Web tools for MoneyForward',
-    version: '1.1.0',
+    version: (
+      JSON.parse(readFileSync('./package.json', 'utf-8')) as { version: string }
+    ).version,
     permissions: ['storage', 'activeTab'],
     host_permissions: ['https://*.moneyforward.com/*'],
   },


### PR DESCRIPTION
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

`manifest.version` in `wxt.config.ts` was hardcoded, causing the zip filename generated by `pnpm zip` to not match the actual version.

## Reason for change

The zip asset for v1.2.0 was named `mf-web-tools-1.1.0-chrome.zip` because the hardcoded version was never updated.

## Changes

- Read `version` dynamically from `package.json` via `readFileSync` in `wxt.config.ts`

## Notes

None.